### PR TITLE
Use tools provider

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 
 	<artifactId>minimaven</artifactId>
-	<version>2.1.5-SNAPSHOT</version>
+	<version>2.2.0-SNAPSHOT</version>
 
 	<name>Minimal support for Maven projects</name>
 	<description>A minimal build system interpreting Maven-style pom.xml files</description>

--- a/src/main/java/org/scijava/minimaven/JavaCompiler.java
+++ b/src/main/java/org/scijava/minimaven/JavaCompiler.java
@@ -37,6 +37,8 @@ import java.io.PrintWriter;
 import java.io.Writer;
 import java.lang.reflect.Method;
 
+import javax.tools.ToolProvider;
+
 import org.scijava.util.FileUtils;
 import org.scijava.util.ProcessUtils;
 
@@ -60,6 +62,11 @@ public class JavaCompiler {
 			boolean verbose) throws CompileError {
 		synchronized(this) {
 			try {
+				javax.tools.JavaCompiler sysc = ToolProvider.getSystemJavaCompiler();
+				if (sysc != null) {
+					sysc.run(null,  out, err, arguments);
+					return;
+				}
 				if (javac == null) {
 					JarClassLoader loader = discoverJavac();
 					Class<?> main = loader == null ?

--- a/src/main/java/org/scijava/minimaven/JavaCompiler.java
+++ b/src/main/java/org/scijava/minimaven/JavaCompiler.java
@@ -61,18 +61,27 @@ public class JavaCompiler {
 
 	// this function handles the javac singleton
 	public void call(String[] arguments,
-			boolean verbose) throws CompileError {
+		boolean verbose) throws CompileError {
+		call(arguments, verbose, false);
+	}
+
+	public void call(String[] arguments,
+			boolean verbose, boolean debug) throws CompileError {
 		synchronized(this) {
 			try {
 				javax.tools.JavaCompiler sysc = ToolProvider.getSystemJavaCompiler();
 				if (sysc != null) {
-					err.print("Found tools compiler: " + sysc.getClass());
-					err.print(ClassUtils.getLocation(sysc.getClass()));
+					if (debug) {
+						err.print("Found tools compiler: " + sysc.getClass());
+						err.print(ClassUtils.getLocation(sysc.getClass()));
+					}
 					sysc.run(null,  out, err, arguments);
 					return;
 				}
-				else {
-					err.println("No java.tools.JavaCompiler available. Checking for explicit javac.");
+
+				if (verbose){
+					err.println(
+						"No javax.tools.JavaCompiler available. Checking for explicit javac.");
 				}
 
 				if (javac == null) {
@@ -98,9 +107,11 @@ public class JavaCompiler {
 				/* re-throw */
 				throw e;
 			} catch (Exception e) {
-				e.printStackTrace(err);
-				err.println("Could not find javac " + e
-					+ ", falling back to system javac");
+				if (verbose) {
+					e.printStackTrace(err);
+					err.println("Could not find javac " + e
+						+ ", falling back to system javac");
+				}
 			}
 		}
 

--- a/src/main/java/org/scijava/minimaven/JavaCompiler.java
+++ b/src/main/java/org/scijava/minimaven/JavaCompiler.java
@@ -39,6 +39,7 @@ import java.lang.reflect.Method;
 
 import javax.tools.ToolProvider;
 
+import org.scijava.util.ClassUtils;
 import org.scijava.util.FileUtils;
 import org.scijava.util.ProcessUtils;
 
@@ -46,6 +47,7 @@ import org.scijava.util.ProcessUtils;
  * Encapsulates the Java compiler, falling back to command-line {@code javac}.
  * 
  * @author Johannes Schindelin
+ * @author Mark Hiner
  */
 public class JavaCompiler {
 	protected PrintStream err, out;
@@ -64,9 +66,15 @@ public class JavaCompiler {
 			try {
 				javax.tools.JavaCompiler sysc = ToolProvider.getSystemJavaCompiler();
 				if (sysc != null) {
+					err.print("Found tools compiler: " + sysc.getClass());
+					err.print(ClassUtils.getLocation(sysc.getClass()));
 					sysc.run(null,  out, err, arguments);
 					return;
 				}
+				else {
+					err.println("No java.tools.JavaCompiler available. Checking for explicit javac.");
+				}
+
 				if (javac == null) {
 					JarClassLoader loader = discoverJavac();
 					Class<?> main = loader == null ?

--- a/src/main/java/org/scijava/minimaven/MavenProject.java
+++ b/src/main/java/org/scijava/minimaven/MavenProject.java
@@ -474,7 +474,7 @@ public class MavenProject implements Comparable<MavenProject> {
 			}
 			String[] array = arguments.toArray(new String[arguments.size()]);
 			if (env.javac != null)
-				env.javac.call(array, env.verbose);
+				env.javac.call(array, env.verbose, env.debug);
 		}
 
 		updateRecursively(resources, target, false);


### PR DESCRIPTION
Update the JavaCompiler to first try the compiler returned by ToolsProvider - which avoids a hard dependency on javac.
